### PR TITLE
fix: ensure err is always sent

### DIFF
--- a/task.go
+++ b/task.go
@@ -39,7 +39,7 @@ func Concurrence(tasks ...Task) Task {
 				if err := tClone(ctx); err != nil {
 					select {
 					case errCh <- err:
-					case <-ctx.Done():
+					default:
 					}
 				}
 				wg.Done()


### PR DESCRIPTION
there was a chance that `ctx.Done()` is prioritised and it means err wouldn't be sent. This diff should fix that.