### PR TITLE
fix: don't close channel

### DIFF
--- a/task.go
+++ b/task.go
@@ -48,7 +48,10 @@ func Concurrence(tasks ...Task) Task {
 
 		go func() {
 			wg.Wait()
-			close(errCh)
+			select {
+			case errCh <- nil:
+			default:
+			}
 		}()
 
 		return <-errCh


### PR DESCRIPTION
Don't close the channel to avoid the chance that err won't be read.